### PR TITLE
Added Toggle show month and year in top

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -5,7 +5,7 @@
     <property id="Use12Hours" type="boolean">false</property>
     <property id="ShowDays" type="boolean">true</property>
     <property id="ShowBottomLeft" type="boolean">true</property>
-    
+    <property id="ShowMonthYear" type="boolean">true</property>
     <property id="Font" type="number">3</property>
 
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -44,6 +44,9 @@
     <setting propertyKey="@Properties.ShowBottomLeft" title="@Strings.ShowBottomLeft">
         <settingConfig type="boolean" />
     </setting>
+    <setting propertyKey="@Properties.ShowMonthYear" title="@Strings.ShowMonthYear">
+        <settingConfig type="boolean" />
+    </setting>
     
     
     

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -6,6 +6,7 @@
     <string id="Use12Hours">12 hours format</string>
     <string id="ShowDays">Show top right info</string>
     <string id="ShowBottomLeft">Show bottom left info</string>
+    <string id="ShowMonthYear">Show top centered info</string>
     <string id="UseBrushFontForInfo">Use brush font for small text</string>
 
     <string id="ColorBlack">Black</string>

--- a/source/phoneBatteryIQView.mc
+++ b/source/phoneBatteryIQView.mc
@@ -117,6 +117,10 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
 		return Application.getApp().getProperty("ShowDays");
 	}
 	
+	function showMonthYear(){
+		return Application.getApp().getProperty("ShowMonthYear");
+	}
+	
 	function showBottomLeft(){
 		return Application.getApp().getProperty("ShowBottomLeft");
 	}	
@@ -214,8 +218,10 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
 //    			dc.drawText(115,135, fontSmall, "B", Graphics.TEXT_JUSTIFY_RIGHT);
 //	        }
 	        
-	        dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
-	        //for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+	        if(showMonthYear()){
+	        	dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
+	        	//for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+	        }
 	        
 	        if(showDays()){
 		        drawWeekDay2(dc,rightTopX,rightTopY,0);
@@ -278,10 +284,11 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
       	var leftBottomX = 135;
       	var leftBottomY = 165;
         
-       
-        dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
-        //for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
-        
+        if(showMonthYear()){
+        	dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
+        	//for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+        }
+               
         if(showDays()){
 	        drawWeekDay2(dc,rightTopX,rightTopY,0);
 	        drawWeekDay2(dc,rightTopX,rightTopY+20,1);
@@ -341,8 +348,10 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
       	var leftBottomY = 170;
         
        
-        dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
-        //for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+        if(showMonthYear()){
+        	dc.drawText(topX,topY, fontMedium, topLabel, Graphics.TEXT_JUSTIFY_CENTER);
+        	//for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+        }
         
         if(showDays()){
 	        drawWeekDay2(dc,rightTopX,rightTopY,0);
@@ -405,8 +414,10 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
       	var leftBottomX = 95;
       	var leftBottomY = 135;
         
-        dc.drawText(topX,topY, getSmallFont(), topLabel, Graphics.TEXT_JUSTIFY_CENTER);
-        //for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+        if(showMonthYear()){
+        	dc.drawText(topX,topY, getSmallFont(), topLabel, Graphics.TEXT_JUSTIFY_CENTER);
+        	//for(var t=1;t<=12;t++){dc.drawText(topX,topY, fontMedium, Lang.format("$1$ $2$",[getMonthName(t),date.year]), Graphics.TEXT_JUSTIFY_CENTER);}
+        }
         
         if(showDays()){
 	        drawWeekDay2(dc,rightTopX,rightTopY,0);
@@ -476,8 +487,10 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
 	      	var leftBottomX = 90;
 	      	var leftBottomY = 120;
 	       
+	        if(showMonthYear()){
+	       		dc.drawText(topX,topY, getSmallFont(), topLabel, Graphics.TEXT_JUSTIFY_LEFT);
+	        }
 	        
-	        dc.drawText(topX,topY, getSmallFont(), topLabel, Graphics.TEXT_JUSTIFY_LEFT);
 	        if(showDays()){
 	        	drawWeekDay2(dc,topX,topY+16,0);
 	        	drawWeekDay2(dc,topX,topY+31,1);
@@ -517,9 +530,9 @@ class phoneBatteryIQView extends WatchUi.WatchFace {
     function onUpdate(dc) {
         //drawWatch(dc);
 
-		System.println(System.getDeviceSettings().screenWidth);
-		System.println(System.getDeviceSettings().screenHeight);
-		System.println(System.getDeviceSettings().screenShape);
+		//System.println(System.getDeviceSettings().screenWidth);
+		//System.println(System.getDeviceSettings().screenHeight);
+		//System.println(System.getDeviceSettings().screenShape);
 		
 		if(ifScreen(215,180,2)){
 			draw_fr230_fr235(dc);	


### PR DESCRIPTION
Hi Victor Paul

I have added an extra setting, to control if the month and year should be shown in top. I like the more clean watchface without this info. 
I have tested it in the simulator with all the supported devices.

Hope you like it and publish it in the Connect IQ Store.

Best regards
Jens